### PR TITLE
Move to rust nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 components = [ "rustfmt", "rustc", "clippy" ]
-channel = "1.58"
+channel = "nightly"

--- a/src/many-abci/src/abci_app.rs
+++ b/src/many-abci/src/abci_app.rs
@@ -33,8 +33,7 @@ impl AbciApp {
         // };
 
         let many_client =
-            ManyClient::new(many_url.clone(), server_id, CoseKeyIdentity::anonymous())
-                .map_err(|e| e)?;
+            ManyClient::new(many_url.clone(), server_id, CoseKeyIdentity::anonymous())?;
         let status = many_client.status().map_err(|x| x.to_string())?;
         let app_name = status.name;
 


### PR DESCRIPTION
This is needed to switch to merk itself (not fmerk) which has had
more development on it, but uses unstable features.
